### PR TITLE
Fix typo on a command in the running services page

### DIFF
--- a/running_services.rst
+++ b/running_services.rst
@@ -152,7 +152,7 @@ identical.
 
     $ singularity instance stop --all
 
-    $ singularity instance stop --a
+    $ singularity instance stop -a
 
 .. note::
     Note that you must escape the wildcard with a backslash like this ``\*`` to


### PR DESCRIPTION
I tried the command, it didn't work as it only allows -a instead of the specified --a.
The typo is not fixed.

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


## This fixes or addresses the following GitHub issues:

- Fixes #
